### PR TITLE
Add quick installation links to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Quality of RWTH browser extension
+
+<p align="center"><a href="https://github.com/Rc-Cookie/quality-of-rwth" target="_blank" rel="noreferrer noopener"><img width="250" alt="HTWR Icon" src="https://github.com/Rc-Cookie/quality-of-rwth/blob/main/Chrome/icons/htwr.png?raw=true"></a></p>
+<p align="center"><strong>Quality of RWTH</strong> improves the usability of RWTH websites.</p>
+<br/>
+<p align="center"><a rel="noreferrer noopener" href="https://chromewebstore.google.com/detail/quality-of-rwth/hhjhbkpidgloeeflpnoajpicjhocbdjk"><img alt="Chrome Web Store" src="https://img.shields.io/badge/Chrome-141e24.svg?&style=for-the-badge&logo=google-chrome&logoColor=white"></a>  <a rel="noreferrer noopener" href="https://addons.mozilla.org/en-US/firefox/addon/quality-of-rwth"><img alt="Firefox Add-ons" src="https://img.shields.io/badge/Firefox-141e24.svg?&style=for-the-badge&logo=firefox-browser&logoColor=white"></a>
+
+## 
 
 This is a browser extension to improve some of the web pages of the RWTH University, particularly those ones who students have to use on a daily basis.
 This includes:


### PR DESCRIPTION
Add links to the chrome web store and firefox addons pages to the README for quick installation.

As https://extension.rwth.cool now links to this GitHub page, it is helpful to have these links ready.

In the future, a simple static website (e.g. using gh pages) for this might be something to add.